### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -17,7 +17,7 @@ cache:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-dist
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpcs --standard=psr2 src/

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "nesbot/carbon": "1.*",
+        "php": ">=7.1",
+        "nesbot/carbon": "2.*",
         "league/flysystem": "^1.0",
         "swiftmailer/swiftmailer": "^5.4",
         "aws/aws-sdk-php": "3.*",
@@ -21,7 +21,7 @@
         "erusev/parsedown": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.*",
+        "phpunit/phpunit": "7.*",
         "squizlabs/php_codesniffer": "2.*"
     },
     "autoload": {

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -1,17 +1,20 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\Arrays;
+
 /**
  * A PHPUnit test case for Arrays.
  */
-class ArraysTest extends PHPUnit_Framework_TestCase
+class ArraysTest extends TestCase
 {
     public function testReset()
     {
-        self::assertEquals(1, \Brunodebarros\Helpers\Arrays::reset([1, 2, 3]));
+        self::assertEquals(1, Arrays::reset([1, 2, 3]));
     }
 
     public function testEnd()
     {
-        self::assertEquals(3, \Brunodebarros\Helpers\Arrays::end([1, 2, 3]));
+        self::assertEquals(3, Arrays::end([1, 2, 3]));
     }
 }

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\Email;
+
 /**
  * A PHPUnit test case for Email.
  */
-class EmailTest extends PHPUnit_Framework_TestCase
+class EmailTest extends TestCase
 {
     public function testNormalizeEmailAddresses()
     {
@@ -11,8 +14,8 @@ class EmailTest extends PHPUnit_Framework_TestCase
         $csv_addresses = 'test@example.com, test@example.service,invalid@email';
         $csv_array_addresses = ['test@example.com, test@example.service,invalid@email'];
 
-        self::assertEquals(['test@example.com', 'test@example.service'], \Brunodebarros\Helpers\Email::normalizeEmailAddresses($addresses));
-        self::assertEquals(['test@example.com', 'test@example.service'], \Brunodebarros\Helpers\Email::normalizeEmailAddresses($csv_addresses));
-        self::assertEquals(['test@example.com', 'test@example.service'], \Brunodebarros\Helpers\Email::normalizeEmailAddresses($csv_array_addresses));
+        self::assertEquals(['test@example.com', 'test@example.service'], Email::normalizeEmailAddresses($addresses));
+        self::assertEquals(['test@example.com', 'test@example.service'], Email::normalizeEmailAddresses($csv_addresses));
+        self::assertEquals(['test@example.com', 'test@example.service'], Email::normalizeEmailAddresses($csv_array_addresses));
     }
 }

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\Filesystem;
+
 /**
  * A PHPUnit test case for Filesystem.
  */
-class FilesystemTest extends PHPUnit_Framework_TestCase
+class FilesystemTest extends TestCase
 {
     /**
      * @var string A sample folder.
@@ -15,7 +18,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
      */
     public $file;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->folder = FCPATH.'filesystem_test';
         $this->file = $this->folder.DIRECTORY_SEPARATOR.'test.txt';
@@ -23,7 +26,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         touch($this->file);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists($this->file)) {
             unlink($this->file);
@@ -36,8 +39,8 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
 
     public function testRrmdir()
     {
-        \Brunodebarros\Helpers\Filesystem::rrmdir($this->folder);
-        self::assertFalse(file_exists($this->folder));
-        self::assertFalse(file_exists($this->file));
+        Filesystem::rrmdir($this->folder);
+        self::assertFileNotExists($this->folder);
+        self::assertFileNotExists($this->file);
     }
 }

--- a/tests/FormattingTest.php
+++ b/tests/FormattingTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\Formatting;
+
 /**
  * A PHPUnit test case for Formatting.
  */
-class FormattingTest extends PHPUnit_Framework_TestCase
+class FormattingTest extends TestCase
 {
     public function testBytes()
     {
@@ -11,7 +14,7 @@ class FormattingTest extends PHPUnit_Framework_TestCase
 
         foreach ($units as $power => $expected_unit) {
             $value = 512 * pow(1024, $power);
-            self::assertEquals("512 $expected_unit", \Brunodebarros\Helpers\Formatting::bytes($value, 2));
+            self::assertEquals("512 $expected_unit", Formatting::bytes($value, 2));
         }
     }
 }

--- a/tests/MiscellaneousTest.php
+++ b/tests/MiscellaneousTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\Miscellaneous;
+
 /**
  * A PHPUnit test case for Miscellaneous.
  */
-class MiscellaneousTest extends PHPUnit_Framework_TestCase
+class MiscellaneousTest extends TestCase
 {
     public function testMultiTrySuccessOnFirstTry()
     {
@@ -14,7 +17,7 @@ class MiscellaneousTest extends PHPUnit_Framework_TestCase
             return true;
         };
 
-        $result = Brunodebarros\Helpers\Miscellaneous::multiTry($test, 3, 100);
+        $result = Miscellaneous::multiTry($test, 3, 100);
 
         self::assertTrue($result);
         self::assertEquals(1, $attempts);
@@ -28,7 +31,7 @@ class MiscellaneousTest extends PHPUnit_Framework_TestCase
             throw new Exception('Test Exception!', $attempts);
         };
 
-        $result = Brunodebarros\Helpers\Miscellaneous::multiTry($test, 3, 100);
+        $result = Miscellaneous::multiTry($test, 3, 100);
 
         self::assertInstanceOf('\\Exception', $result);
         self::assertEquals(3, $result->getCode());
@@ -47,7 +50,7 @@ class MiscellaneousTest extends PHPUnit_Framework_TestCase
             }
         };
 
-        $result = Brunodebarros\Helpers\Miscellaneous::multiTry($test, 3, 100);
+        $result = Miscellaneous::multiTry($test, 3, 100);
 
         self::assertTrue($result);
         self::assertEquals(3, $attempts);
@@ -65,7 +68,7 @@ class MiscellaneousTest extends PHPUnit_Framework_TestCase
             }
         };
 
-        $result = Brunodebarros\Helpers\Miscellaneous::multiTry($test, 3, 100);
+        $result = Miscellaneous::multiTry($test, 3, 100);
 
         self::assertTrue($result);
         self::assertEquals(3, $attempts);

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -1,19 +1,22 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use Brunodebarros\Helpers\System;
+
 /**
  * A PHPUnit test case for System.
  */
-class SystemTest extends PHPUnit_Framework_TestCase
+class SystemTest extends TestCase
 {
     public function testRunLs()
     {
         $outputs = [];
 
-        $result = \Brunodebarros\Helpers\System::run('ls', function ($output) use (&$outputs) {
+        $result = System::run('ls', function ($output) use (&$outputs) {
             $outputs[] = $output;
-        }, dirname(__FILE__));
+        }, __DIR__);
 
-        self::assertTrue(in_array(basename(__FILE__), $outputs));
+        self::assertContains(basename(__FILE__), $outputs);
         self::assertContains(basename(__FILE__), $result['output']);
         self::assertEquals(0, $result['exit_code']);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,9 @@
 <?php
 
-define('FCPATH', dirname(__FILE__).DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR);
+define('FCPATH', __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR);
 define('ENV_TIMEZONE', 'Europe/London');
 define('DATETIME_FORMAT', 'd/m/Y h:i A');
 define('DATE_FORMAT', 'd/m/Y');
 define('TIME_FORMAT', 'h:i A');
 
-require dirname(__FILE__).DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php';
+require __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php';


### PR DESCRIPTION
# Changed log
- It's related to issue #1.
- Using install is good enough to install current dependencies.
- Add the `PHPUnit\Framework\TestCase` namespace to be compatible with future `PHPUnit` version.
- The `php-5.5` version is deprecated. Using the `php-7.1` version at least.
It also upgrades the PHPUnit version to `7.x`.
- The `nesbot/carbon:^1.x` version is deprecated since upgrading the PHP version to `7.1+`.
Using the `nesbot/carbon:^2.x` version instead.